### PR TITLE
Update cca_core.py with correct numpy LinAlg error check

### DIFF
--- a/cca_core.py
+++ b/cca_core.py
@@ -396,7 +396,7 @@ def robust_cca_similarity(acts1, acts2, threshold=0.98, epsilon=1e-6,
   for trial in range(num_cca_trials):
     try:
       return_dict = get_cca_similarity(acts1, acts2, threshold, compute_dirns)
-    except np.LinAlgError:
+    except np.linalg.LinAlgError:
       acts1 = acts1*1e-1 + np.random.normal(size=acts1.shape)*epsilon
       acts2 = acts2*1e-1 + np.random.normal(size=acts1.shape)*epsilon
       if trial + 1 == num_cca_trials:


### PR DESCRIPTION
It seems when checking for numpy linalg error (usually thrown when SVD does not converge) in the robust_cca_similarity function, the exception should be np.linalg.LinAlg and not np.LinAlg